### PR TITLE
Cleanexport

### DIFF
--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -12,8 +12,6 @@ document.addEventListener('DOMContentLoaded', function(){
           console.log(file.size)
           console.log(file.type)
           console.log(file.lastModifiedData)
-          console.log(file.fullPath) // not real full path due to browser security restrictions
-          console.log(file.path) // in Electron, this contains the actual full path
       
           // convert the file to a Buffer that we can use!
           var reader = new FileReader()
@@ -40,10 +38,8 @@ document.addEventListener('DOMContentLoaded', function(){
       let button = document.getElementById('export-btn');
       button.addEventListener('click', (event) => {
         event.preventDefault();
-	window.location = '/api/export';
-        /*$.get('/api/export', (data) => {
-          console.log(data);
-        })*/
+	      window.location = '/api/export';
+
       });
     }
     

--- a/routes/api.js
+++ b/routes/api.js
@@ -53,13 +53,13 @@ router.get('/export', (req, res) => {
     function streamToCSV(categories, meta){
         console.log(categories, meta);
         
-        let category_list = categories.map(category => Object.assign({}, category))
+        const category_list = categories.map(category => Object.assign({}, category))
         
         csvStream.pipe(writableStream);
 
         if (meta.current_page < meta.total_pages) {
             category_list.forEach(category => csvStream.write(category))
-            let path = meta.links.next;
+            const path = meta.links.next;
 
             return exportCategories(bc, path);
         }

--- a/routes/api.js
+++ b/routes/api.js
@@ -42,7 +42,7 @@ router.get('/export', (req, res) => {
     let csvStream = csv.createWriteStream({headers: true});
     let writableStream = fs.createWriteStream(filename);
     
-    function exportCategories(bc_api, path='?page=1&limit=250') {
+    function exportCategories(bc_api, path) {
         bc_api.get(`/catalog/categories${path}`)
         .then(categories => {
             streamToCSV(categories.data, categories.meta.pagination);
@@ -84,7 +84,7 @@ router.get('/export', (req, res) => {
     }
 
     if (bc) {
-        exportCategories(bc);
+        exportCategories(bc, '?page=1&limit=250');
     }
 })
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -41,7 +41,7 @@ router.get('/export', (req, res) => {
 
     let csvStream = csv.createWriteStream({headers: true});
     let writableStream = fs.createWriteStream(filename);
-    
+    csvStream.pipe(writableStream);
     function exportCategories(bc_api, path) {
         bc_api.get(`/catalog/categories${path}`)
         .then(categories => {
@@ -55,11 +55,12 @@ router.get('/export', (req, res) => {
         
         const category_list = categories.map(category => Object.assign({}, category))
         console.log(`cat length: ${category_list.length}`);
-        csvStream.pipe(writableStream);
+        //csvStream.pipe(writableStream);
 
         function determinePageForCSV(){
-        
+                console.log(`writing page: ${meta.current_page}`);
                 if (meta.current_page < meta.total_pages) {
+                    
                     //category_list.forEach(category => csvStream.write(category))
                     //return exportCategories(bc, path);
                     category_list.forEach(writeToCSV);

--- a/routes/api.js
+++ b/routes/api.js
@@ -57,17 +57,37 @@ router.get('/export', (req, res) => {
         console.log(`cat length: ${category_list.length}`);
         csvStream.pipe(writableStream);
 
-        if (meta.current_page < meta.total_pages) {
-            category_list.forEach(category => csvStream.write(category))
-            const path = meta.links.next;
+        function determinePageForCSV(){
+        
+                if (meta.current_page < meta.total_pages) {
+                    //category_list.forEach(category => csvStream.write(category))
+                    //return exportCategories(bc, path);
+                    category_list.forEach(writeToCSV);
+                }
+                if (meta.current_page == meta.total_pages) {
+                    //category_list.forEach(category => csvStream.write(category));
+                    //csvStream.end();
+                    category_list.forEach(writeAndPublishCSV);
+                }
+                function writeToCSV(element, index, array){
+                    if (index == array.length - 1) {
+                        csvStream.write(element);
+                        const path = meta.links.next;
+                        console.log(`path: ${path}`);
+                        return exportCategories(bc, path);
+                    } else {
+                        csvStream.write(element);
+                    }
+                }
 
-            return exportCategories(bc, path);
-        }
-
-        if (meta.current_page == meta.total_pages) {
-            category_list.forEach(category => csvStream.write(category));
-
-            csvStream.end();
+                function writeAndPublishCSV(element, index, array) {
+                    if (index == array.length - 1) {
+                        csvStream.write(element);
+                        csvStream.end()
+                    } else {
+                        csvStream.write(element);
+                    }
+                }
         }
 
         writableStream.on('finish', function(){

--- a/routes/api.js
+++ b/routes/api.js
@@ -38,10 +38,11 @@ router.get('/export', (req, res) => {
 
     let date = new Date().toDateString().split(' ').join('');
     let filename = `category-export-${date}.csv`;
-
     let csvStream = csv.createWriteStream({headers: true});
     let writableStream = fs.createWriteStream(filename);
+
     csvStream.pipe(writableStream);
+    
     function exportCategories(bc_api, path) {
         bc_api.get(`/catalog/categories${path}`)
         .then(categories => {
@@ -51,38 +52,28 @@ router.get('/export', (req, res) => {
     }
 
     function streamToCSV(categories, meta){
-        //console.log(categories, meta);
         
         const category_list = categories.map(category => Object.assign({}, category))
-        console.log(`cat length: ${category_list.length}`);
-        //csvStream.pipe(writableStream);
 
         function determinePageForCSV(current_categories){
                 
                 if (meta.current_page < meta.total_pages) {
-                    console.log(`writing page: ${meta.current_page}`);
-                    //category_list.forEach(category => csvStream.write(category))
-                    //return exportCategories(bc, path);
                     current_categories.forEach(writeToCSV);
                 }
                 if (meta.current_page == meta.total_pages) {
-                    console.log(`writing what should be the last page: ${meta.current_page}`);
-                    //category_list.forEach(category => csvStream.write(category));
-                    //csvStream.end();
                     current_categories.forEach(writeAndPublishCSV);
                 }
+
                 function writeToCSV(element, index, array){
-                    //console.log(index, array.length);
                     if (index == array.length - 1) {
                         csvStream.write(element);
                         const path = meta.links.next;
-                        console.log(`path: ${path}`);
+
                         exportCategories(bc, path);
                     } else {
                         csvStream.write(element);
                     }
                 }
-
                 function writeAndPublishCSV(element, index, array) {
                     if (index == array.length - 1) {
                         csvStream.write(element);
@@ -92,6 +83,7 @@ router.get('/export', (req, res) => {
                     }
                 }
         }
+
         determinePageForCSV(category_list);
 
         function sendCSV(){

--- a/routes/api.js
+++ b/routes/api.js
@@ -70,11 +70,12 @@ router.get('/export', (req, res) => {
                     category_list.forEach(writeAndPublishCSV);
                 }
                 function writeToCSV(element, index, array){
+                    console.log(index, array.length);
                     if (index == array.length - 1) {
                         csvStream.write(element);
                         const path = meta.links.next;
                         console.log(`path: ${path}`);
-                        return exportCategories(bc, path);
+                        exportCategories(bc, path);
                     } else {
                         csvStream.write(element);
                     }

--- a/routes/api.js
+++ b/routes/api.js
@@ -51,10 +51,10 @@ router.get('/export', (req, res) => {
     }
 
     function streamToCSV(categories, meta){
-        console.log(categories, meta);
+        //console.log(categories, meta);
         
         const category_list = categories.map(category => Object.assign({}, category))
-        
+        console.log(`cat length: ${category_list.length}`);
         csvStream.pipe(writableStream);
 
         if (meta.current_page < meta.total_pages) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -58,10 +58,7 @@ router.get('/export', (req, res) => {
         csvStream.pipe(writableStream);
 
         if (meta.current_page < meta.total_pages) {
-            console.log('meta.current_page < meta.total_pages');
-
             category_list.forEach(category => csvStream.write(category))
-
             let path = meta.links.next;
 
             return exportCategories(bc, path);
@@ -80,7 +77,7 @@ router.get('/export', (req, res) => {
             if (err) {
                 console.log(`csv send err: ${err}`)
             }
-        });
+            });
 
         });
         
@@ -90,5 +87,10 @@ router.get('/export', (req, res) => {
         exportCategories(bc);
     }
 })
+
+router.post('/import', (req, res) => {
+    res.send('You are importing a file');
+})
+
 
 module.exports = router;

--- a/routes/api.js
+++ b/routes/api.js
@@ -57,18 +57,19 @@ router.get('/export', (req, res) => {
         console.log(`cat length: ${category_list.length}`);
         //csvStream.pipe(writableStream);
 
-        function determinePageForCSV(){
-                console.log(`writing page: ${meta.current_page}`);
+        function determinePageForCSV(current_categories){
+                
                 if (meta.current_page < meta.total_pages) {
-                    
+                    console.log(`writing page: ${meta.current_page}`);
                     //category_list.forEach(category => csvStream.write(category))
                     //return exportCategories(bc, path);
-                    category_list.forEach(writeToCSV);
+                    current_categories.forEach(writeToCSV);
                 }
                 if (meta.current_page == meta.total_pages) {
+                    console.log(`writing what should be the last page: ${meta.current_page}`);
                     //category_list.forEach(category => csvStream.write(category));
                     //csvStream.end();
-                    category_list.forEach(writeAndPublishCSV);
+                    current_categories.forEach(writeAndPublishCSV);
                 }
                 function writeToCSV(element, index, array){
                     //console.log(index, array.length);
@@ -85,24 +86,28 @@ router.get('/export', (req, res) => {
                 function writeAndPublishCSV(element, index, array) {
                     if (index == array.length - 1) {
                         csvStream.write(element);
-                        csvStream.end()
+                        sendCSV();
                     } else {
                         csvStream.write(element);
                     }
                 }
         }
-        determinePageForCSV();
+        determinePageForCSV(category_list);
 
-        writableStream.on('finish', function(){
-            console.log('Done with CSV');
-
-            res.download(filename, (err) => {
-            if (err) {
-                console.log(`csv send err: ${err}`)
-            }
+        function sendCSV(){
+            csvStream.end()
+            writableStream.on('finish', function(){
+                console.log('Done with CSV');
+    
+                res.download(filename, (err) => {
+                if (err) {
+                    console.log(`csv send err: ${err}`)
+                }
+                });
+    
             });
-
-        });
+        }
+        
         
     }
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -70,7 +70,7 @@ router.get('/export', (req, res) => {
                     category_list.forEach(writeAndPublishCSV);
                 }
                 function writeToCSV(element, index, array){
-                    console.log(index, array.length);
+                    //console.log(index, array.length);
                     if (index == array.length - 1) {
                         csvStream.write(element);
                         const path = meta.links.next;
@@ -90,6 +90,7 @@ router.get('/export', (req, res) => {
                     }
                 }
         }
+        determinePageForCSV();
 
         writableStream.on('finish', function(){
             console.log('Done with CSV');


### PR DESCRIPTION
Export categories to a CSV in the order they appear on pages returned from the API.

todo:
Handle nested object for custom_urls; split into separate columns or write stringified, acting as a read only type value for imports