### PR TITLE
Smartimport

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -189,11 +189,15 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
             'image_url': data['Category Image URL'],
             'is_visible': yesNoToBoolean(data['Category Visible']),
             'search_keywords': data['Search Keywords'],
-            'default_product_sort': data['Default Product Sort'] || 'use_store_settings',
-            'custom_url': {
-                'url': data['Category URL'] || null,
-                'is_customized': yesNoToBoolean(data['Custom URL']) || null
+            'default_product_sort': data['Default Product Sort'] || 'use_store_settings'
+        }
+        if (data['Category URL'] && data['Custom URL']) {
+            newCategory['custom_url'] = {
+                'url': data['Category URL'],
+                'is_customized': yesNoToBoolean(data['Custom URL'])
             }
+        }
+            
         }
         return categoryArray.push(newCategory);
     }

--- a/routes/api.js
+++ b/routes/api.js
@@ -129,7 +129,7 @@ router.get('/export', (req, res) => {
                         'Search Keywords': category['search_keywords'],
                         'Default Product Sort': category['default_product_sort'],
                         'Category URL': category['custom_url']['url'],
-                        'Custom URL': category['custom_url']['is_customized'],
+                        'Custom URL': stringToYesNo(category['custom_url']['is_customized']),
                     }
                 }
 
@@ -223,7 +223,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
         const count = categories.length - 1;
         res.send({'import': 'started'});
         console.log(categories);
-        //writeCategoryToBC(categories, count, 1);
+        writeCategoryToBC(categories, count, 1);
     }
 
     function writeCategoryToBC(queue, count, index){

--- a/routes/api.js
+++ b/routes/api.js
@@ -138,21 +138,21 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
     };
     //ignoring id for now in headers
     //TODO: handle ID and default product sort
-    const headers = [ , 'parent_id', 'name', 'description', 'sort_order', 'page_title', 'meta_keywords', 'meta_description', 'image_url', 'is_visible', 'search_keywords'];
+    //const headers = [ , 'parent_id', 'name', 'description', 'sort_order', 'page_title', 'meta_keywords', 'meta_description', 'image_url', 'is_visible', 'search_keywords'];
 
     class UploadProcess extends EventEmitter {}
     const uploadProcess = new UploadProcess();
 
     csvStream
-    .fromStream(uploadedCSV, {headers: headers})
+    .fromStream(uploadedCSV, {headers: true})
     .on('error', err => {
         importResults.started = false;
         res.status('400').send('Error: CSV is not in expected format\nCheck instructions for format help.');
     })
-    .on('data', data=>readyCategories(data))
+    .on('data', data=>prepareCategories(data))
     .on('end', ()=> uploadProcess.emit('done', categoryArray));
 
-    function readyCategories(data){
+    function prepareCategories(data){
         //Convert data from CSV into acceptable format for BC API
         data['meta_keywords'] = [data['meta_keywords']];
 
@@ -177,7 +177,8 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
     function createCategories(categories, bc) {
         const count = categories.length - 1;
         res.send({"import": "started"});
-        writeCategoryToBC(categories, count, 1);
+        console.log(categories);
+        //writeCategoryToBC(categories, count, 1);
     }
 
     function writeCategoryToBC(queue, count, index){

--- a/routes/api.js
+++ b/routes/api.js
@@ -40,7 +40,7 @@ router.get('/single', (req,res) => {
 // When a user hits the export button all categories
 // will be exported into a CSV file
 router.get('/export', (req, res) => {
-    console.log("session:",req.session);
+    console.log('session:',req.session);
     let hash = req.session.storehash;
     let bc;
 
@@ -81,20 +81,39 @@ router.get('/export', (req, res) => {
 
                 function writeToCSV(element, index, array){
                     if (index == array.length - 1) {
-                        csvStream.write(element);
+                        csvStream.write(formatExportContent(element));
                         const path = meta.links.next;
 
                         exportCategories(bc, path);
                     } else {
-                        csvStream.write(element);
+                        csvStream.write(formatExportContent(element));
                     }
                 }
                 function writeAndPublishCSV(element, index, array) {
                     if (index == array.length - 1) {
-                        csvStream.write(element);
+                        csvStream.write(formatExportContent(element));
                         sendCSV();
                     } else {
-                        csvStream.write(element);
+                        csvStream.write(formatExportContent(element));
+                    }
+                }
+
+                function formatExportContent(category) {
+                    return {
+                        'ID': parseInt(category['id']),
+                        'Parent ID': parseInt(category['parent_id']),
+                        'Name': category['name'],
+                        'Description': category['description'],
+                        'Sort Order': category['sort_order'],
+                        'Page Title': category['page_title'],
+                        'Meta Keywords': category['meta_keywords'],
+                        'Meta Description': category['meta_description'],
+                        'Image URL': category['image_url'],
+                        'Visible': category['is_visible'],
+                        'Search Keywords': category['search_keywords'],
+                        'Default Product Sort': category['default_product_sort'],
+                        'Custom URL': category['custom_url']['is_customized'],
+                        'URL': category['custom_url']['url']
                     }
                 }
         }
@@ -176,7 +195,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
 
     function createCategories(categories, bc) {
         const count = categories.length - 1;
-        res.send({"import": "started"});
+        res.send({'import': 'started'});
         console.log(categories);
         //writeCategoryToBC(categories, count, 1);
     }
@@ -222,7 +241,7 @@ router.get('/progress', (req, res) => {
 
 router.get('/restart', (req, res) => {
     importResults.started = false;
-    res.send({"acknowledged": true})
+    res.send({'acknowledged': true})
 })
 
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,6 +13,22 @@ const upload = multer({limits: {files: 1, fileSize: 1000000}, storage: storage }
 const streamifier = require('streamifier');
 const EventEmitter = require('events');
 
+function stringToYesNo(string) {
+    if (string.toString().toLowerCase() == 'true') {
+        return 'Y';
+    } else {
+        return 'N';
+    }
+}
+
+function yesNoToBoolean(string) {
+    if (string.toLowerCase() == 'y') {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 // TEST ROUTE to generate a category
 router.get('/single', (req,res) => {
     let bc;
@@ -100,22 +116,24 @@ router.get('/export', (req, res) => {
 
                 function formatExportContent(category) {
                     return {
-                        'ID': parseInt(category['id']),
+                        'Category ID': parseInt(category['id']),
                         'Parent ID': parseInt(category['parent_id']),
-                        'Name': category['name'],
-                        'Description': category['description'],
+                        'Category Name': category['name'],
+                        'Category Description': category['description'],
                         'Sort Order': category['sort_order'],
                         'Page Title': category['page_title'],
                         'Meta Keywords': category['meta_keywords'],
                         'Meta Description': category['meta_description'],
-                        'Image URL': category['image_url'],
-                        'Visible': category['is_visible'],
+                        'Category Image URL': category['image_url'],
+                        'Category Visible': stringToYesNo(category['is_visible']),
                         'Search Keywords': category['search_keywords'],
                         'Default Product Sort': category['default_product_sort'],
+                        'Category URL': category['custom_url']['url'],
                         'Custom URL': category['custom_url']['is_customized'],
-                        'URL': category['custom_url']['url']
                     }
                 }
+
+                
         }
 
         determinePageForCSV(category_list);
@@ -173,15 +191,23 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
 
     function prepareCategories(data){
         //Convert data from CSV into acceptable format for BC API
-        data['meta_keywords'] = [data['meta_keywords']];
 
-        if (data['is_visible'].toLowerCase() == 'true') {
-            data['is_visible'] = true;
-        } else {
-            data['is_visible'] = false;
+        newCategory = {
+            'parent_id': data['Parent ID'],
+            'name': data['Category Name'],
+            'description': data['Category Description'],
+            'sort_order': data['Sort Order'],
+            'page_title': data['Page Title'],
+            'meta_keywords': [data['Meta Keywords']],
+            'meta_description': data['Meta Description'],
+            'image_url': data['Category Image URL'],
+            'is_visible': yesNoToBoolean(data['Category Visible']),
+            'search_keywords': data['Search Keywords'],
+            'default_product_sort': data['Default Product Sort'],
+            'category_url': data['Category URL']
         }
 
-        return categoryArray.push(data);
+        return categoryArray.push(newCategory);
     }
 
     uploadProcess.on('done', (categories)=> {

--- a/routes/api.js
+++ b/routes/api.js
@@ -193,7 +193,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
         //Convert data from CSV into acceptable format for BC API
 
         newCategory = {
-            'parent_id': data['Parent ID'],
+            'parent_id': data['Parent ID'] || 0,
             'name': data['Category Name'],
             'description': data['Category Description'],
             'sort_order': data['Sort Order'],

--- a/routes/api.js
+++ b/routes/api.js
@@ -232,7 +232,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
         if (index <= count) {
             checkForExistingCategory(categoryToImport)
             .then(apiResponse => {
-                if (apiResponse.data.length > 1) {
+                if (apiResponse.data.length >= 1) {
                     let categoryToUpdate = apiResponse.data.filter(existingCategory => {
                         return existingCategory['parent_id'] == categoryToImport['parent_id'];
                     });

--- a/routes/api.js
+++ b/routes/api.js
@@ -215,7 +215,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
 
     function checkForExistingCategory(category) {
         const name = category['name'];
-        return bc.get(`/catalog/categories?name=${name}`);
+        return bc.get(`/catalog/categories?name=${encodeURIComponent(name)}`);
     }
     
     function updateExistingCategory(categoryToUpdate, categoryData) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -219,7 +219,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
     }
     
     function updateExistingCategory(categoryToUpdate, categoryData) {
-        return bc.put(`/catalog/categories$${categoryToUpdate['id']}`, categoryData);
+        return bc.put(`/catalog/categories/${categoryToUpdate['id']}`, categoryData);
     }
 
     function createNewCategory(category) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -137,6 +137,14 @@ router.get('/export', (req, res) => {
                     if (err) {
                         console.log(`csv send err: ${err}`)
                     }
+                    else {
+                        fs.unlink(filename, (err) => {
+                            if (err) {
+                                throw err;
+                            }
+                            console.log(`${filename} removed after download`)
+                        });
+                    }
                 });
             });
         }

--- a/routes/api.js
+++ b/routes/api.js
@@ -189,10 +189,10 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
             'image_url': data['Category Image URL'],
             'is_visible': yesNoToBoolean(data['Category Visible']),
             'search_keywords': data['Search Keywords'],
-            'default_product_sort': data['Default Product Sort'],
+            'default_product_sort': data['Default Product Sort'] || 'use_store_settings',
             'custom_url': {
-                'url': data['Category URL'],
-                'is_customized': yesNoToBoolean(data['Custom URL'])
+                'url': data['Category URL'] || null,
+                'is_customized': yesNoToBoolean(data['Custom URL']) || null
             }
         }
         return categoryArray.push(newCategory);

--- a/routes/api.js
+++ b/routes/api.js
@@ -198,7 +198,6 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
             }
         }
             
-        }
         return categoryArray.push(newCategory);
     }
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -236,9 +236,11 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
                     let categoryToUpdate = apiResponse.data.filter(existingCategory => {
                         return existingCategory['parent_id'] == categoryToImport['parent_id'];
                     });
+                    console.log('Updating category: ', categoryToUpdate[0]);
                     return updateExistingCategory(categoryToUpdate[0], categoryToImport);
                 }
                 else {
+                    console.log('Creating new category: ', apiResponse.data)
                     return createNewCategory(categoryToImport);
                 }
             })

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,10 +1,5 @@
 const express = require('express');
 const router = express.Router();
-/*
-const session = require('express-session');
-const BigCommerce = require('node-bigcommerce');
-const mysql = require('mysql');
-*/
 const bcAuth = require('../lib/bc_auth');
 const csv = require('fast-csv');
 const fs = require('fs');
@@ -215,7 +210,7 @@ router.post('/import', upload.single('csvFile'), (req, res) => {
     function initImport(categories) {
         const count = categories.length - 1;
         res.send({'import': 'started'});
-        iterateCategories(categories, count, 1);
+        iterateCategories(categories, count, 0);
     }
 
     function checkForExistingCategory(category) {

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const router = express.Router();
+/*
 const session = require('express-session');
 const BigCommerce = require('node-bigcommerce');
 const mysql = require('mysql');
+*/
 const bcAuth = require('../lib/bc_auth');
 const csv = require('fast-csv');
 const fs = require('fs');


### PR DESCRIPTION
Importing a CSV now checks for existing categories and updates them.

The format of the CSV is also more user friendly - headers match the convention used by BigCommerce's native product import CSV format. Previously headers were pulled directly from the property names used by the API.

The order of columns no longer matters - only the names of the headers themselves.

Separately, exporting CSVs no longer keeps the 'temporary' file on disk forever - after files are downloaded by a user they're cleaned up.