### PR TITLE
Storing store hash in session after install

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -126,7 +126,7 @@ router.get('/', (req, res) => {
 
         function routeUserAfterAuth(){
             req.session.validated = true;
-            req.session.storehash = storehash;
+            req.session.storehash = bcDetails.storeHash;
             res.redirect('/');
         }
 


### PR DESCRIPTION
Adding storehash to session after successful auth. Previously this was only done correctly on the load route.